### PR TITLE
feat(cli): add size subcommand; polish CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,54 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  python:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     env:
-      PYTHONPATH: ${{ github.workspace }}
+      MPLBACKEND: Agg
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      - run: python -m pip install -U pip
-      - run: python -m pip install -r requirements.txt
-      - run: python -m pip install black ruff pytest
-      - run: python -m ruff check . --output-format=github || true
-      - run: python -m black --check .
-      - run: python -m pytest -q
+          python-version: ${{ matrix.python-version }}
+          cache: pip
 
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          # install your package + dev tools from pyproject extras
+          python -m pip install -e .[dev]
+
+      - name: Lint (ruff)
+        run: python -m ruff check .
+
+      - name: Format check (black)
+        run: python -m black --check .
+
+      - name: Tests
+        run: python -m pytest -q
+
+      # Collect artifacts on failure (handy for debugging)
+      - name: Upload test artifacts (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ matrix.python-version }}
+          path: |
+            .pytest_cache
+            reports
+          if-no-files-found: ignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black  # uses [tool.black] in pyproject.toml
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: [--fix]  # auto-fix lint issues when possible
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml

--- a/README.md
+++ b/README.md
@@ -6,30 +6,55 @@
 Pipeline to ingest raw events, compute daily aggregates (events, DAU, optional p50/p95 latency), and generate charts + metrics.  
 Built as an end-to-end telemetry workflow prototype.
 
+**Highlights**
+- CSV → Parquet ingest with UTC-normalized timestamps
+- Daily aggregates: events per (date, feature_id), DAU per day, optional p50/p95 latency
+- Reports: feature-usage bar chart + metrics.txt summary
+- CLI size command to compare CSV vs Parquet on-disk size
+- Tested end-to-end (function calls + CLI) with pytest; edge cases covered
+
+---
+
+## Install
+
+**Option A (recommended: via `pyproject.toml`)**
+```bash
+python -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip
+pip install -e .[dev]   # installs package + dev tools (pytest/ruff/etc.)
+```
+
+**Option B (requirements.txt)**
+```bash
+python -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip
+pip install -r requirements.txt
+```
+
 ---
 
 ## Run in 30 seconds
 
 ```bash
-python -m venv .venv && source .venv/bin/activate
-python -m pip install -r requirements.txt
-
 python -m tlt.cli ingest --input sample/events.csv --out data/events.parquet
 python -m tlt.cli transform --in data/events.parquet --out data/agg.parquet
 python -m tlt.cli report --in data/agg.parquet --out reports/
+python -m tlt.cli size --csv sample/events.csv --parquet data/events.parquet
 ```
 
 **Outputs**
-- `data/events.parquet` (raw events in parquet)
+- `data/events.parquet` (raw events in Parquet)
 - `data/agg.parquet` (aggregated metrics)
 - `reports/feature_usage.png`, `reports/metrics.txt`
+
+> The `size` command prints a small report to stdout (no file written).
 
 ---
 
 ## Requirements
 - Python 3.11+
-- See `requirements.txt` for dependencies:
-  - pandas, pyarrow, matplotlib, click, pytest
+- Key deps: pandas, pyarrow, matplotlib, click (pytest/ruff/black as dev extras)
+- Notes: timestamps are normalized to tz-aware **UTC** during ingest; matplotlib runs headless (**Agg**) in CI.
 
 ---
 
@@ -43,14 +68,14 @@ Below is an example chart generated from the pipeline:
 ## Sample Metrics (`reports/metrics.txt`)
 
 ```txt
-=== Telemetry Summary ===
-Aggregated days: 7
-Total events: 12,345
-Features: 6
-Mean DAU: 128.4
-Max DAU: 191
-Median latency p50 (overall mean): 51.2 ms
-Tail latency p95 (overall mean): 54.6 ms
+Telemetry Summary:
+- Aggregated days: 7
+- Total events: 12,345
+- Features: 6
+- Mean DAU: 128.4
+- Max DAU: 191
+- Median latency p50 (overall mean): 51.2 ms
+- Tail latency p95 (overall mean): 54.6 ms
 ```
 
 ---
@@ -62,7 +87,25 @@ python -m tlt.cli --help
 python -m tlt.cli ingest --help
 python -m tlt.cli transform --help
 python -m tlt.cli report --help
+python -m tlt.cli size --help
 ```
+
+If you installed with console scripts (`pip install -e .`), you can also run `tlt ...` instead of `python -m tlt.cli ...`.
+
+---
+
+## Tests
+
+Run the test suite:
+```bash
+pytest -q
+```
+
+What’s covered:
+- End-to-end happy path (`tests/test_flow.py`)
+- CLI smoke test via subprocess (`tests/test_cli.py`)
+- Edge cases for schema & timestamp parsing (`tests/test_edge_cases.py`)
+- Size command (`tests/test_size.py`)
 
 ---
 
@@ -70,20 +113,26 @@ python -m tlt.cli report --help
 ```
 telemetry-dashboard/
   tlt/
+    __init__.py
     cli.py         # CLI entrypoint (Click)
-    ingest.py      # CSV -> parquet
+    ingest.py      # CSV -> Parquet (UTC-normalized timestamps)
     transform.py   # aggregates (events, DAU, optional p50/p95)
-    report.py      # charts + metrics
+    report.py      # charts + metrics (feature usage, metrics.txt)
+    size.py        # CSV vs Parquet size report (CLI: `size`)
   sample/
     events.csv     # sample dataset
   tests/
-    test_flow.py   # end-to-end test
+    test_flow.py       # end-to-end test
+    test_cli.py        # CLI smoke test
+    test_edge_cases.py # ingest schema/timestamp failures
+    test_size.py       # size subcommand test
   scripts/
-    add_latency.py # helper to inject latency_ms into events
+    add_latency.py     # helper to inject latency_ms into events
   docs/
     feature_usage_sample.png
   .github/workflows/ci.yml
-  requirements.txt
+  pyproject.toml   # or requirements.txt (if using Option B)
+  pytest.ini
   README.md
 ```
 
@@ -93,9 +142,10 @@ telemetry-dashboard/
 - [x] Add latency column to sample data and visualize p50/p95
 - [ ] Add rolling 30d MAU
 - [ ] Add per-feature latency distributions
-- [ ] Add CSV/Parquet size comparisons
+- [x] Add CSV/Parquet size comparisons
 
 ---
 
 ## License
 MIT © 2025 John Dawood
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "ruff",
-    "mypy",
+    "pytest>=8.2.0,<9",
+    "ruff>=0.5.0",
+    "black>=24.4.0",
+    "mypy>=1.10.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "telemetry-dashboard"
+version = "0.1.0"
+description = "End-to-end telemetry pipeline: ingest → transform → report."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [{ name = "John Dawood" }]
+keywords = ["telemetry", "analytics", "etl", "metrics"]
+
+# Runtime deps only
+dependencies = [
+    "pandas",
+    "pyarrow",
+    "matplotlib",
+    "click",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff",
+    "mypy",
+]
+
+[project.scripts]
+tlt = "tlt.cli:cli"
+
+[project.urls]
+Homepage = "https://github.com/jdawood1/telemetry-dashboard"
+
+# Make package discovery explicit (your package is the top-level 'tlt/' dir)
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["tlt*"]
+
+# pytest config lives nicely here too
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+# basic Ruff config
+[tool.ruff]
+line-length = 100
+target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,8 @@ addopts = "-q"
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+# basic Black config
+[tool.black]
+line-length = 100
+target-version = ["py311"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pandas>=2.2.2
 pyarrow>=17.0.0
 matplotlib>=3.9.0
-pydantic>=2.8.0
 pytest>=8.2.0
 click>=8.1.7

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,26 +19,47 @@ def test_cli_smoke(tmp_path: Path) -> None:
     agg_parquet = data / "agg.parquet"
 
     # ingest
-    subprocess.check_call([
-        _py(), "-m", "tlt.cli", "ingest",
-        "--input", str(SAMPLE),
-        "--out", str(events_parquet),
-    ])
+    subprocess.check_call(
+        [
+            _py(),
+            "-m",
+            "tlt.cli",
+            "ingest",
+            "--input",
+            str(SAMPLE),
+            "--out",
+            str(events_parquet),
+        ]
+    )
     assert events_parquet.exists()
 
     # transform
-    subprocess.check_call([
-        _py(), "-m", "tlt.cli", "transform",
-        "--in", str(events_parquet),
-        "--out", str(agg_parquet),
-    ])
+    subprocess.check_call(
+        [
+            _py(),
+            "-m",
+            "tlt.cli",
+            "transform",
+            "--in",
+            str(events_parquet),
+            "--out",
+            str(agg_parquet),
+        ]
+    )
     assert agg_parquet.exists()
 
     # report
-    subprocess.check_call([
-        _py(), "-m", "tlt.cli", "report",
-        "--in", str(agg_parquet),
-        "--out", str(reports),
-    ])
+    subprocess.check_call(
+        [
+            _py(),
+            "-m",
+            "tlt.cli",
+            "report",
+            "--in",
+            str(agg_parquet),
+            "--out",
+            str(reports),
+        ]
+    )
     assert (reports / "feature_usage.png").exists()
     assert (reports / "metrics.txt").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+REPO = Path(__file__).resolve().parents[1]
+SAMPLE = REPO / "sample" / "events.csv"
+
+
+def _py() -> str:
+    return sys.executable
+
+
+def test_cli_smoke(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    reports = tmp_path / "reports"
+    events_parquet = data / "events.parquet"
+    agg_parquet = data / "agg.parquet"
+
+    # ingest
+    subprocess.check_call([
+        _py(), "-m", "tlt.cli", "ingest",
+        "--input", str(SAMPLE),
+        "--out", str(events_parquet),
+    ])
+    assert events_parquet.exists()
+
+    # transform
+    subprocess.check_call([
+        _py(), "-m", "tlt.cli", "transform",
+        "--in", str(events_parquet),
+        "--out", str(agg_parquet),
+    ])
+    assert agg_parquet.exists()
+
+    # report
+    subprocess.check_call([
+        _py(), "-m", "tlt.cli", "report",
+        "--in", str(agg_parquet),
+        "--out", str(reports),
+    ])
+    assert (reports / "feature_usage.png").exists()
+    assert (reports / "metrics.txt").exists()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -10,11 +10,13 @@ from tlt.ingest import ingest_csv
 def test_ingest_missing_columns(tmp_path: Path) -> None:
     csv = tmp_path / "bad.csv"
     # Missing feature_id
-    pd.DataFrame({
-        "timestamp": ["2025-01-01T00:00:00Z"],
-        "user_id": ["u1"],
-        "event": ["click"],
-    }).to_csv(csv, index=False)
+    pd.DataFrame(
+        {
+            "timestamp": ["2025-01-01T00:00:00Z"],
+            "user_id": ["u1"],
+            "event": ["click"],
+        }
+    ).to_csv(csv, index=False)
 
     with pytest.raises(ValueError) as ei:
         ingest_csv(csv, tmp_path / "out.parquet")
@@ -24,12 +26,14 @@ def test_ingest_missing_columns(tmp_path: Path) -> None:
 
 def test_ingest_bad_timestamp(tmp_path: Path) -> None:
     csv = tmp_path / "bad_ts.csv"
-    pd.DataFrame({
-        "timestamp": ["not-a-time"],
-        "user_id": ["u1"],
-        "event": ["click"],
-        "feature_id": ["f1"],
-    }).to_csv(csv, index=False)
+    pd.DataFrame(
+        {
+            "timestamp": ["not-a-time"],
+            "user_id": ["u1"],
+            "event": ["click"],
+            "feature_id": ["f1"],
+        }
+    ).to_csv(csv, index=False)
 
     with pytest.raises(ValueError) as ei:
         ingest_csv(csv, tmp_path / "out.parquet")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+import pytest
+
+from tlt.ingest import ingest_csv
+
+
+def test_ingest_missing_columns(tmp_path: Path) -> None:
+    csv = tmp_path / "bad.csv"
+    # Missing feature_id
+    pd.DataFrame({
+        "timestamp": ["2025-01-01T00:00:00Z"],
+        "user_id": ["u1"],
+        "event": ["click"],
+    }).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError) as ei:
+        ingest_csv(csv, tmp_path / "out.parquet")
+
+    assert "Missing required columns" in str(ei.value)
+
+
+def test_ingest_bad_timestamp(tmp_path: Path) -> None:
+    csv = tmp_path / "bad_ts.csv"
+    pd.DataFrame({
+        "timestamp": ["not-a-time"],
+        "user_id": ["u1"],
+        "event": ["click"],
+        "feature_id": ["f1"],
+    }).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError) as ei:
+        ingest_csv(csv, tmp_path / "out.parquet")
+
+    # your ingest raises on unparsable timestamps
+    assert "timestamps could not be parsed" in str(ei.value).lower()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,22 +1,44 @@
+# tests/test_flow.py
+from __future__ import annotations
+
 from pathlib import Path
+import pandas as pd
+
 from tlt.ingest import ingest_csv
 from tlt.transform import transform_parquet
 from tlt.report import make_reports
 
-SAMPLE = Path("sample/events.csv")
+# Resolve the sample file relative to the repo root, not CWD
+REPO = Path(__file__).resolve().parents[1]
+SAMPLE = REPO / "sample" / "events.csv"
 
 
-def test_flow(tmp_path: Path):
+def test_flow(tmp_path: Path) -> None:
     raw = tmp_path / "events.parquet"
     agg = tmp_path / "agg.parquet"
     out = tmp_path / "reports"
 
-    ingest_csv(SAMPLE, raw)
+    # Ingest
+    p_raw = ingest_csv(SAMPLE, raw)
     assert raw.exists()
+    assert p_raw == raw
 
-    transform_parquet(raw, agg)
+    # Transform
+    p_agg = transform_parquet(raw, agg)
     assert agg.exists()
+    assert p_agg == agg
 
-    make_reports(agg, out)
+    # Basic schema sanity
+    df_agg = pd.read_parquet(agg)
+    assert {"date", "feature_id", "events"}.issubset(df_agg.columns)
+    assert "dau" in df_agg.columns  # produced per-day
+
+    # Report
+    p_out = make_reports(agg, out)
+    assert p_out == out
     assert (out / "feature_usage.png").exists()
-    assert (out / "metrics.txt").exists()
+
+    metrics = out / "metrics.txt"
+    assert metrics.exists()
+    txt = metrics.read_text(encoding="utf-8")
+    assert "Telemetry Summary" in txt

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+def _py() -> str:
+    return sys.executable
+
+def test_size_cmd(tmp_path: Path) -> None:
+    # minimal CSV + Parquet roundtrip through CLI
+    csv = tmp_path / "x.csv"
+    csv.write_text("timestamp,user_id,event,feature_id\n2025-01-01T00:00:00Z,u1,open,f1\n", encoding="utf-8")
+
+    # ingest to get parquet
+    events_parquet = tmp_path / "x.parquet"
+    subprocess.check_call([
+        _py(), "-m", "tlt.cli", "ingest",
+        "--input", str(csv),
+        "--out", str(events_parquet),
+    ])
+    out = subprocess.check_output([
+        _py(), "-m", "tlt.cli", "size",
+        "--csv", str(csv),
+        "--parquet", str(events_parquet),
+    ], text=True)
+    assert "Size Comparison" in out
+    assert "Parquet/CSV ratio" in out

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -4,25 +4,44 @@ from pathlib import Path
 import subprocess
 import sys
 
+
 def _py() -> str:
     return sys.executable
+
 
 def test_size_cmd(tmp_path: Path) -> None:
     # minimal CSV + Parquet roundtrip through CLI
     csv = tmp_path / "x.csv"
-    csv.write_text("timestamp,user_id,event,feature_id\n2025-01-01T00:00:00Z,u1,open,f1\n", encoding="utf-8")
+    csv.write_text(
+        "timestamp,user_id,event,feature_id\n2025-01-01T00:00:00Z,u1,open,f1\n", encoding="utf-8"
+    )
 
     # ingest to get parquet
     events_parquet = tmp_path / "x.parquet"
-    subprocess.check_call([
-        _py(), "-m", "tlt.cli", "ingest",
-        "--input", str(csv),
-        "--out", str(events_parquet),
-    ])
-    out = subprocess.check_output([
-        _py(), "-m", "tlt.cli", "size",
-        "--csv", str(csv),
-        "--parquet", str(events_parquet),
-    ], text=True)
+    subprocess.check_call(
+        [
+            _py(),
+            "-m",
+            "tlt.cli",
+            "ingest",
+            "--input",
+            str(csv),
+            "--out",
+            str(events_parquet),
+        ]
+    )
+    out = subprocess.check_output(
+        [
+            _py(),
+            "-m",
+            "tlt.cli",
+            "size",
+            "--csv",
+            str(csv),
+            "--parquet",
+            str(events_parquet),
+        ],
+        text=True,
+    )
     assert "Size Comparison" in out
     assert "Parquet/CSV ratio" in out

--- a/tlt/cli.py
+++ b/tlt/cli.py
@@ -1,88 +1,127 @@
+from __future__ import annotations
+
 from pathlib import Path
+from inspect import signature
 import click
 
 from .ingest import ingest_csv
 from .transform import transform_parquet
 from .report import make_reports
+from . import size as size_mod
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
-@click.group()
-def cli():
-    """Telemetry pipeline CLI: ingest -> transform -> report."""
+def _call_with_supported_args(func, /, *args, **kwargs):
+    """Call func with only the kwargs it supports (safe pass-through)."""
+    params = set(signature(func).parameters)
+    filtered = {k: v for k, v in kwargs.items() if k in params}
+    return func(*args, **filtered)
+
+
+@click.group(
+    help="Telemetry pipeline CLI: ingest → transform → report.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.version_option(package_name="telemetry-dashboard")
+def cli() -> None:
     pass
 
 
-@cli.command("ingest")
+@cli.command("ingest", short_help="CSV → Parquet")
 @click.option(
-    "--input",
+    "--input", "-i",
     "input_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
     help="Input CSV with columns: timestamp,user_id,event,feature_id[,latency_ms]",
 )
 @click.option(
-    "--out",
+    "--out", "-o",
     "out_path",
     type=click.Path(dir_okay=False, path_type=Path),
     required=True,
-    help="Output parquet path (parent dir will be created).",
+    help="Output Parquet path (parent dir will be created).",
 )
-def ingest_cmd(input_path: Path, out_path: Path):
-    """Read CSV -> write parquet."""
+def ingest_cmd(input_path: Path, out_path: Path) -> None:
+    """Read CSV → write Parquet."""
     try:
-        p = ingest_csv(input_path, out_path)
+        p = _call_with_supported_args(ingest_csv, input_path, out_path)
         click.echo(f"Wrote: {p}")
     except Exception as e:
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
 
-@cli.command("transform")
+@cli.command("transform", short_help="Aggregate daily metrics")
 @click.option(
-    "--in",
-    "in_path",
+    "--in", "in_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
-    help="Input parquet from ingest step.",
+    help="Input Parquet from ingest step.",
 )
 @click.option(
-    "--out",
-    "out_path",
+    "--out", "out_path",
     type=click.Path(dir_okay=False, path_type=Path),
     required=True,
-    help="Output aggregated parquet (parent dir will be created).",
+    help="Output aggregated Parquet (parent dir will be created).",
 )
-def transform_cmd(in_path: Path, out_path: Path):
-    """Aggregate metrics: events per (date,feature), DAU per date, optional p50/p95 latency."""
+@click.option(
+    "--mau-window",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Rolling MAU window (days). Forwarded if supported.",
+)
+def transform_cmd(in_path: Path, out_path: Path, mau_window: int) -> None:
+    """Aggregate metrics: events/day+feature, DAU/day, optional p50/p95 latency, and MAU."""
     try:
-        p = transform_parquet(in_path, out_path)
+        p = _call_with_supported_args(
+            transform_parquet,
+            in_path, out_path,
+            mau_window=mau_window,
+        )
         click.echo(f"Wrote: {p}")
     except Exception as e:
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
 
-@cli.command("report")
+@cli.command("report", short_help="Generate charts + metrics")
 @click.option(
-    "--in",
-    "in_path",
+    "--in", "in_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
-    help="Input aggregated parquet from transform step.",
+    help="Input aggregated Parquet from transform step.",
 )
 @click.option(
-    "--out",
-    "out_dir",
+    "--out", "out_dir",
     type=click.Path(file_okay=False, path_type=Path),
     required=True,
     help="Output directory for reports (metrics.txt, charts). Will be created.",
 )
-def report_cmd(in_path: Path, out_dir: Path):
-    """Generate text and chart reports from aggregated parquet."""
+@click.option(
+    "--events",
+    "events_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=False,
+    help="(Optional) Raw events Parquet for per-feature latency plots and better latency stats.",
+)
+def report_cmd(in_path: Path, out_dir: Path, events_path: Path | None) -> None:
+    """Generate text and chart reports from aggregated Parquet."""
     try:
-        p = make_reports(in_path, out_dir)
+        p = _call_with_supported_args(make_reports, in_path, out_dir, events_path=events_path)
         click.echo(f"Wrote reports to: {p}")
     except Exception as e:
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
+@cli.command("size", short_help="Compare CSV vs Parquet sizes")
+@click.option("--csv", "csv_path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+@click.option("--parquet", "parquet_path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+def size_cmd(csv_path: Path, parquet_path: Path) -> None:
+    try:
+        txt = size_mod.compare(csv_path, parquet_path)
+        click.echo(txt)
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
 
 if __name__ == "__main__":
     cli()

--- a/tlt/cli.py
+++ b/tlt/cli.py
@@ -30,14 +30,16 @@ def cli() -> None:
 
 @cli.command("ingest", short_help="CSV → Parquet")
 @click.option(
-    "--input", "-i",
+    "--input",
+    "-i",
     "input_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
     help="Input CSV with columns: timestamp,user_id,event,feature_id[,latency_ms]",
 )
 @click.option(
-    "--out", "-o",
+    "--out",
+    "-o",
     "out_path",
     type=click.Path(dir_okay=False, path_type=Path),
     required=True,
@@ -54,13 +56,15 @@ def ingest_cmd(input_path: Path, out_path: Path) -> None:
 
 @cli.command("transform", short_help="Aggregate daily metrics")
 @click.option(
-    "--in", "in_path",
+    "--in",
+    "in_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
     help="Input Parquet from ingest step.",
 )
 @click.option(
-    "--out", "out_path",
+    "--out",
+    "out_path",
     type=click.Path(dir_okay=False, path_type=Path),
     required=True,
     help="Output aggregated Parquet (parent dir will be created).",
@@ -77,7 +81,8 @@ def transform_cmd(in_path: Path, out_path: Path, mau_window: int) -> None:
     try:
         p = _call_with_supported_args(
             transform_parquet,
-            in_path, out_path,
+            in_path,
+            out_path,
             mau_window=mau_window,
         )
         click.echo(f"Wrote: {p}")
@@ -87,13 +92,15 @@ def transform_cmd(in_path: Path, out_path: Path, mau_window: int) -> None:
 
 @cli.command("report", short_help="Generate charts + metrics")
 @click.option(
-    "--in", "in_path",
+    "--in",
+    "in_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
     help="Input aggregated Parquet from transform step.",
 )
 @click.option(
-    "--out", "out_dir",
+    "--out",
+    "out_dir",
     type=click.Path(file_okay=False, path_type=Path),
     required=True,
     help="Output directory for reports (metrics.txt, charts). Will be created.",
@@ -113,15 +120,24 @@ def report_cmd(in_path: Path, out_dir: Path, events_path: Path | None) -> None:
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
+
 @cli.command("size", short_help="Compare CSV vs Parquet sizes")
-@click.option("--csv", "csv_path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
-@click.option("--parquet", "parquet_path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+@click.option(
+    "--csv", "csv_path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True
+)
+@click.option(
+    "--parquet",
+    "parquet_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+)
 def size_cmd(csv_path: Path, parquet_path: Path) -> None:
     try:
         txt = size_mod.compare(csv_path, parquet_path)
         click.echo(txt)
     except Exception as e:
         raise click.ClickException(str(e)) from e
+
 
 if __name__ == "__main__":
     cli()

--- a/tlt/ingest.py
+++ b/tlt/ingest.py
@@ -1,23 +1,67 @@
+from __future__ import annotations
 from pathlib import Path
 import pandas as pd
 
 
 def ingest_csv(input_path: str | Path, out_path: str | Path) -> Path:
-    input_path, out_path = Path(input_path), Path(out_path)
+    """
+    Ingest a CSV of telemetry events and write normalized Parquet.
 
-    # auto-create parent dir (so "data/" exists)
+    Required columns:
+      - timestamp (ISO8601; parsed to tz-aware UTC)
+      - user_id    (string)
+      - event      (string)
+      - feature_id (string)
+
+    Optional columns:
+      - latency_ms (numeric; coerced if present)
+    """
+    input_path, out_path = Path(input_path), Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # read input CSV
-    df = pd.read_csv(input_path)
+    # Read with stable dtypes; avoid "object" surprises in groupbys
+    df = pd.read_csv(
+        input_path,
+        dtype={
+            "user_id": "string",
+            "event": "string",
+            "feature_id": "string",
+        },
+        # Keep literal "NA" strings as data (not NaN); we’ll validate nulls explicitly
+        keep_default_na=False,
+    )
 
-    # basic sanity: required cols
+    # ---- Schema & null validation ----
     required = {"timestamp", "user_id", "event", "feature_id"}
     missing = required - set(df.columns)
     if missing:
-        raise ValueError(f"Missing required columns: {missing}")
+        raise ValueError(f"Missing required columns: {sorted(missing)}")
 
-    # save as parquet
-    df.to_parquet(out_path, index=False)
+    # Normalize timestamp to tz-aware UTC
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    if df["timestamp"].isna().any():
+        n = int(df["timestamp"].isna().sum())
+        raise ValueError(f"{n} timestamps could not be parsed.")
+
+    # Coerce latency if present (non-fatal; rows keep NaN where invalid)
+    if "latency_ms" in df.columns:
+        df["latency_ms"] = pd.to_numeric(df["latency_ms"], errors="coerce")
+
+    # Enforce non-null for key identifiers
+    for col in ("user_id", "event", "feature_id"):
+        if df[col].isna().any() or (df[col].astype("string").str.len() == 0).any():
+            raise ValueError(f"Column '{col}' contains null/empty values.")
+
+    # Deterministic order helps diffs and downstream expectations
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    # Prefer compression if available; fall back gracefully
+    try:
+        df.to_parquet(out_path, index=False, compression="zstd")
+    except Exception:
+        try:
+            df.to_parquet(out_path, index=False, compression="snappy")
+        except Exception:
+            df.to_parquet(out_path, index=False)
 
     return out_path

--- a/tlt/report.py
+++ b/tlt/report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from pathlib import Path
 import pandas as pd
 import matplotlib
+
 matplotlib.use("Agg")  # CI/headless
 import matplotlib.pyplot as plt
 
@@ -41,7 +42,9 @@ def _plot_latency_box_by_feature(events: pd.DataFrame, out_path: Path) -> None:
     plt.close()
 
 
-def make_reports(in_path: str | Path, out_dir: str | Path, events_path: str | Path | None = None) -> Path:
+def make_reports(
+    in_path: str | Path, out_dir: str | Path, events_path: str | Path | None = None
+) -> Path:
     in_path, out_dir = Path(in_path), Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -103,11 +106,12 @@ def make_reports(in_path: str | Path, out_dir: str | Path, events_path: str | Pa
             total_events = len(df)
             n_users = df["user_id"].nunique()
             n_features = df["feature_id"].nunique()
-            n_days = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.floor("D").nunique()
+            n_days = (
+                pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.floor("D").nunique()
+            )
             f.write(f"Days: {n_days}\n")
             f.write(f"Events: {total_events}\n")
             f.write(f"Unique users: {n_users}\n")
             f.write(f"Features: {n_features}\n")
 
     return out_dir
-

--- a/tlt/report.py
+++ b/tlt/report.py
@@ -1,77 +1,113 @@
+from __future__ import annotations
 from pathlib import Path
 import pandas as pd
 import matplotlib
-
 matplotlib.use("Agg")  # CI/headless
 import matplotlib.pyplot as plt
 
 
-def make_reports(in_path: str | Path, out_dir: str | Path) -> Path:
+def _plot_feature_usage(series: pd.Series, out_path: Path) -> None:
+    plt.figure()
+    series.plot(kind="bar")
+    plt.title("Feature Usage (Total Events)")
+    plt.xlabel("feature_id")
+    plt.ylabel("events")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig(out_path)
+    plt.close()
+
+
+def _plot_latency_box_by_feature(events: pd.DataFrame, out_path: Path) -> None:
+    """Boxplot of latency_ms grouped by feature_id (from raw events)."""
+    if not {"feature_id", "latency_ms"}.issubset(events.columns):
+        return
+    data = []
+    labels = []
+    for feat, df_f in events.groupby("feature_id"):
+        s = pd.to_numeric(df_f["latency_ms"], errors="coerce").dropna()
+        if not s.empty:
+            data.append(s.values)
+            labels.append(str(feat))
+    if not data:
+        return
+    plt.figure()
+    plt.boxplot(data, labels=labels, showfliers=False)
+    plt.title("Latency by Feature (boxplot)")
+    plt.ylabel("Latency (ms)")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig(out_path)
+    plt.close()
+
+
+def make_reports(in_path: str | Path, out_dir: str | Path, events_path: str | Path | None = None) -> Path:
     in_path, out_dir = Path(in_path), Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_parquet(in_path)
+    events_df = None
+    if events_path:
+        try:
+            events_df = pd.read_parquet(events_path)
+        except Exception:
+            events_df = None  # Optional
 
     # ---- Determine schema: raw vs aggregated ----
     is_agg = {"date", "feature_id", "events"}.issubset(df.columns)
 
-    # ---- Feature usage chart (works for raw or agg) ----
+    # ---- Feature usage chart ----
     if is_agg:
         usage = df.groupby("feature_id")["events"].sum().sort_values(ascending=False)
     else:
-        # raw: count events per feature
         usage = df.groupby("feature_id").size().sort_values(ascending=False)
+    _plot_feature_usage(usage, out_dir / "feature_usage.png")
 
-    plt.figure()
-    usage.plot(kind="bar")
-    plt.title("Feature Usage (Total Events)")
-    plt.xlabel("feature_id")
-    plt.ylabel("events")
-    plt.tight_layout()
-    plt.savefig(out_dir / "feature_usage.png")
-    plt.close()
+    # ---- Optional latency-by-feature chart from raw events ----
+    if events_df is not None:
+        _plot_latency_box_by_feature(events_df, out_dir / "latency_by_feature.png")
 
     # ---- Text metrics ----
     metrics_path = out_dir / "metrics.txt"
-    with open(metrics_path, "w") as f:
+    with open(metrics_path, "w", encoding="utf-8") as f:
         f.write("=== Telemetry Summary ===\n")
 
         if is_agg:
             total_events = int(df["events"].sum())
-            n_days = df["date"].nunique()
+            n_days = pd.to_datetime(df["date"]).dt.floor("D").nunique()
             n_features = df["feature_id"].nunique()
             f.write(f"Aggregated days: {n_days}\n")
             f.write(f"Total events: {total_events}\n")
             f.write(f"Features: {n_features}\n")
 
-            # If DAU column exists, report stats
             if "dau" in df.columns:
-                # overall unique users can't be derived exactly from agg;
-                # report mean/max DAU instead
-                dau_by_day = df.drop_duplicates("date")[["date", "dau"]].set_index(
-                    "date"
-                )["dau"]
+                dau_by_day = df.groupby("date")["dau"].max()
                 f.write(f"Mean DAU: {float(dau_by_day.mean()):.1f}\n")
                 f.write(f"Max DAU: {int(dau_by_day.max())}\n")
 
-            # Optional latency if present
-            if {"p50", "p95"}.issubset(df.columns):
-                f.write(
-                    f"Median latency p50 (overall mean): {pd.to_numeric(df['p50'], errors='coerce').mean():.1f} ms\n"
-                )
-                f.write(
-                    f"Tail latency p95 (overall mean): {pd.to_numeric(df['p95'], errors='coerce').mean():.1f} ms\n"
-                )
+            mau_col = next((c for c in df.columns if str(c).startswith("mau_")), None)
+            if mau_col:
+                latest_mau = int(df.sort_values("date").groupby("date")[mau_col].max().iloc[-1])
+                f.write(f"{mau_col.upper()} (most recent day): {latest_mau}\n")
 
+            # If p50/p95 exist in aggregated rows, report overall means of those stats
+            if {"p50", "p95"}.issubset(df.columns):
+                mean_p50 = pd.to_numeric(df["p50"], errors="coerce").mean()
+                mean_p95 = pd.to_numeric(df["p95"], errors="coerce").mean()
+                if pd.notna(mean_p50):
+                    f.write(f"Median latency p50 (overall mean): {mean_p50:.1f} ms\n")
+                if pd.notna(mean_p95):
+                    f.write(f"Tail latency p95 (overall mean): {mean_p95:.1f} ms\n")
         else:
             # raw schema
             total_events = len(df)
             n_users = df["user_id"].nunique()
             n_features = df["feature_id"].nunique()
-            n_days = pd.to_datetime(df["timestamp"]).dt.date.nunique()
+            n_days = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.floor("D").nunique()
             f.write(f"Days: {n_days}\n")
             f.write(f"Events: {total_events}\n")
             f.write(f"Unique users: {n_users}\n")
             f.write(f"Features: {n_features}\n")
 
     return out_dir
+

--- a/tlt/size.py
+++ b/tlt/size.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pathlib import Path
+
+def _fmt(n: int) -> str:
+    units = ["B","KB","MB","GB","TB"]
+    x = float(n); i = 0
+    while x >= 1024 and i < len(units)-1:
+        x /= 1024; i += 1
+    return f"{x:.1f} {units[i]}"
+
+def compare(csv_path: str | Path, parquet_path: str | Path) -> str:
+    csv_p, pq_p = Path(csv_path), Path(parquet_path)
+    if not csv_p.exists(): raise FileNotFoundError(csv_p)
+    if not pq_p.exists(): raise FileNotFoundError(pq_p)
+    c, p = csv_p.stat().st_size, pq_p.stat().st_size
+    ratio = (p / c) if c else float("inf")
+    return (
+        "=== Size Comparison ===\n"
+        f"CSV:     {_fmt(c)}  ({c} bytes)\n"
+        f"Parquet: {_fmt(p)}  ({p} bytes)\n"
+        f"Parquet/CSV ratio: {ratio:.3f}\n"
+    )

--- a/tlt/size.py
+++ b/tlt/size.py
@@ -1,19 +1,31 @@
 from __future__ import annotations
+
 from pathlib import Path
 
+
 def _fmt(n: int) -> str:
-    units = ["B","KB","MB","GB","TB"]
-    x = float(n); i = 0
-    while x >= 1024 and i < len(units)-1:
-        x /= 1024; i += 1
+    units = ["B", "KB", "MB", "GB", "TB"]
+    x = float(n)
+    i = 0
+    while x >= 1024 and i < len(units) - 1:
+        x /= 1024
+        i += 1
     return f"{x:.1f} {units[i]}"
 
+
 def compare(csv_path: str | Path, parquet_path: str | Path) -> str:
-    csv_p, pq_p = Path(csv_path), Path(parquet_path)
-    if not csv_p.exists(): raise FileNotFoundError(csv_p)
-    if not pq_p.exists(): raise FileNotFoundError(pq_p)
-    c, p = csv_p.stat().st_size, pq_p.stat().st_size
+    csv_p = Path(csv_path)
+    pq_p = Path(parquet_path)
+
+    if not csv_p.exists():
+        raise FileNotFoundError(csv_p)
+    if not pq_p.exists():
+        raise FileNotFoundError(pq_p)
+
+    c = csv_p.stat().st_size
+    p = pq_p.stat().st_size
     ratio = (p / c) if c else float("inf")
+
     return (
         "=== Size Comparison ===\n"
         f"CSV:     {_fmt(c)}  ({c} bytes)\n"

--- a/tlt/transform.py
+++ b/tlt/transform.py
@@ -3,44 +3,68 @@ from pathlib import Path
 import pandas as pd
 
 
-def transform_parquet(in_path: str | Path, out_path: str | Path) -> Path:
+def _compute_mau(events: pd.DataFrame, window_days: int = 30) -> pd.DataFrame:
+    """
+    Exact MAU per day: count of unique users active in the trailing `window_days` (inclusive).
+    Requires 'date' as DatetimeIndex-like column (floored to day).
+    """
+    active = events[["date", "user_id"]].drop_duplicates().assign(present=1)
+    pivot = active.pivot_table(
+        index="date", columns="user_id", values="present", aggfunc="max", fill_value=0
+    )
+    # time-based rolling window (e.g., '30D')
+    rolled = pivot.rolling(f"{window_days}D", min_periods=1).sum()
+    mau = (rolled > 0).sum(axis=1).rename(f"mau_{window_days}d")
+    return mau.reset_index()  # columns: ['date', f'mau_{window_days}d']
+
+
+def transform_parquet(
+        in_path: str | Path,
+        out_path: str | Path,
+        mau_window: int = 30,
+) -> Path:
     """
     Read raw events parquet, compute daily aggregates, and write an aggregated parquet.
 
-    Produces:
-      - events per (date, feature_id)
-      - dau per date (distinct users/day)
-      - if 'latency_ms' exists: p50/p95 latency per (date, feature_id)
+    Produces one row per (date, feature_id):
+      - events
+      - p50 / p95 latency (if latency_ms present)
+      - dau per day (duplicated across features for convenience)
+      - mau_{mau_window}d per day (duplicated across features)
     """
     in_path, out_path = Path(in_path), Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_parquet(in_path)
 
-    # ensure timestamp -> date
-    df["date"] = pd.to_datetime(df["timestamp"]).dt.date
+    # Ensure timestamp and 'date' (floor to day, keep as datetime64 for parquet + rolling ops)
+    ts = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    if ts.isna().any():
+        raise ValueError("Some timestamps could not be parsed.")
+    df = df.copy()
+    df["date"] = ts.dt.floor("D")
 
     # events per (date, feature)
     events = df.groupby(["date", "feature_id"]).size().reset_index(name="events")
-
-    # DAU per day
-    dau = df.groupby("date")["user_id"].nunique().reset_index(name="dau")
 
     # optional latency metrics if present
     if "latency_ms" in df.columns:
         lat = (
             df.groupby(["date", "feature_id"])["latency_ms"]
-            .agg(p50=lambda s: s.quantile(0.5), p95=lambda s: s.quantile(0.95))
+            .agg(p50=lambda s: float(s.quantile(0.5)), p95=lambda s: float(s.quantile(0.95)))
             .reset_index()
         )
         agg = events.merge(lat, on=["date", "feature_id"], how="left")
     else:
-        agg = events.copy()
-        agg["p50"] = pd.NA
-        agg["p95"] = pd.NA
+        agg = events.assign(p50=pd.NA, p95=pd.NA)
 
-    # join DAU (broadcast per date)
+    # DAU per day (distinct users)
+    dau = df.groupby("date")["user_id"].nunique().reset_index(name="dau")
     agg = agg.merge(dau, on="date", how="left")
+
+    # MAU (rolling exact)
+    mau = _compute_mau(df, window_days=mau_window)
+    agg = agg.merge(mau, on="date", how="left")
 
     agg.to_parquet(out_path, index=False)
     return out_path

--- a/tlt/transform.py
+++ b/tlt/transform.py
@@ -19,9 +19,9 @@ def _compute_mau(events: pd.DataFrame, window_days: int = 30) -> pd.DataFrame:
 
 
 def transform_parquet(
-        in_path: str | Path,
-        out_path: str | Path,
-        mau_window: int = 30,
+    in_path: str | Path,
+    out_path: str | Path,
+    mau_window: int = 30,
 ) -> Path:
     """
     Read raw events parquet, compute daily aggregates, and write an aggregated parquet.


### PR DESCRIPTION
- New 'tlt size' CLI to compare CSV vs Parquet sizes
- UTC-normalized ingest + stricter validation
- README: install options, CLI updates, tests section
- CI: matrix (3.11/3.12), caching, headless MPL
- Tests: E2E, CLI smoke, edge cases, size command